### PR TITLE
use the PATH to find ruby

### DIFF
--- a/contents/generate.rb
+++ b/contents/generate.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/bin/env ruby
 
 require 'rubygems'
 require 'json'


### PR DESCRIPTION
Instead of hard-coding the path to ruby, it should be discovered by using the `/bin/env` command so that this plugin is compatible with Puppet Enterprise which stores Ruby at /opt/puppet/bin/ruby.
